### PR TITLE
Modify song: The Legend of Zelda Breath of the Wild - Hyrule Castle

### DIFF
--- a/z64database.json
+++ b/z64database.json
@@ -370,9 +370,9 @@
     "file": "Banjo-Kazooie/Bubblegoop Swamp.ootrs"
   },
   {
-    "game": "Breath of the Wild",
-    "song": "Hyrule Field",
-    "type": "Bgm",
+    "game": "The Legend of Zelda Breath of the Wild",
+    "song": "Hyrule Castle",
+    "type": "bgm",
     "categories": [
       "HyruleField",
       "LostWoods",
@@ -401,6 +401,13 @@
     "usesCustomBank": false,
     "usesCustomSamples": false,
     "uuid": "32233e2f-ff2b-45ed-81da-ec3bd9dc580e",
-    "file": "Breath of the Wild/Hyrule Field.ootrs"
+    "file": "Breath of the Wild/Hyrule Field.ootrs",
+    "composers": [
+      "IDK"
+    ],
+    "converters": [
+      "Tolin"
+    ],
+    "preview": "https://www.youtube.com/watch?v=J-I6td_UvWY&ab_channel=Darunia%27sJoy"
   }
 ]


### PR DESCRIPTION
## Modify song: The Legend of Zelda Breath of the Wild - Hyrule Castle
### User's notes:
"None"
### Entry added:
<details>
<summary>Spoiler</summary>

```
{
  "game": "The Legend of Zelda Breath of the Wild",
  "song": "Hyrule Castle",
  "type": "bgm",
  "categories": [
    "HyruleField",
    "LostWoods",
    "GerudoValley",
    "Fields",
    "Outdoors",
    "Overworld",
    "InsideDekuTree",
    "DodongosCavern",
    "JabuJabu",
    "ForestTemple",
    "IceCavern",
    "FireTemple",
    "WaterTemple",
    "SpiritTemple",
    "ShadowTemple",
    "CastleUnderground",
    "CastleEscape",
    "ChildDungeon",
    "AncientDungeon",
    "MysticalDungeon",
    "SpookyDungeon",
    "AdultDungeon",
    "Dungeon"
  ],
  "usesCustomBank": false,
  "usesCustomSamples": false,
  "uuid": "32233e2f-ff2b-45ed-81da-ec3bd9dc580e",
  "file": "Breath of the Wild/Hyrule Field.ootrs",
  "composers": [
    "IDK"
  ],
  "converters": [
    "Tolin"
  ],
  "preview": "https://www.youtube.com/watch?v=J-I6td_UvWY&ab_channel=Darunia%27sJoy"
}
```

</details>